### PR TITLE
Add some german resources

### DIFF
--- a/public/resources.json
+++ b/public/resources.json
@@ -162,5 +162,21 @@
         "title": "Free japanese fonts",
         "description": "280 Japanese unicode fonts free to download.",
         "hasText": false
+    },
+    {
+        "type": "reading",
+        "languages": ["german"],
+        "url": "https://www.nachrichtenleicht.de",
+        "title": "Nachrichtenleicht",
+        "description": "A news site operated by Deutschlandfunk that publishes weekly news stories written in simple language for language learners on various topics including current events, culture, sports, and others.",
+        "hasText": true
+    },
+    {
+        "type": "audio",
+        "languages": ["german"],
+        "url": "https://learngerman.dw.com/de/deutsch-lernen/s-9095",
+        "title": "DW Deutsch Lernen",
+        "description": "Resources for german learners provided by Deutsche Welle (DW) including longer form videos, vocabulary, and placement tests. In addition to that, nearly every day, new short form audio broadcasts with manuscripts are posted. Content varies from A1-C2 levels.",
+        "hasText": true
     }
 ]


### PR DESCRIPTION
This PR just adds a couple resources I've found useful while learning German. [Nachrichtenleicht](https://www.nachrichtenleicht.de), in particular, is a great source of comprehensible news stories for importing into LinguaCafe.

It looks like it renders fine, but do let me know if any changes need to be made.
![image](https://github.com/user-attachments/assets/eb0c688c-83d3-4677-8495-7fda2a816acf)

Thanks for the great resource :+1: 