### PR TITLE
Fix dead link

### DIFF
--- a/public/resources.json
+++ b/public/resources.json
@@ -190,8 +190,8 @@
     {
         "type": "audio",
         "languages": ["german"],
-        "url": "https://www.swr.de/swrkultur/programm/swr2-wissen-podcast-102.html",
-        "title": "SWR2 Wissen",
+        "url": "https://www.swr.de/swrkultur/programm/podcast-swr-das-wissen-102.html",
+        "title": "SWR: Das Wissen",
         "description": "A podcast from Südwestrundfunk (SWR). Topics include current events, history, and general education. Manuscripts for each podcast are available directly in the description of each episode or via link to download as a PDF.",
         "hasText": true
     },


### PR DESCRIPTION
The link to the SWR: Das Wissen podcast was moved without a proper redirect.